### PR TITLE
Alterado retorno do metodo

### DIFF
--- a/pom-infobec.xml
+++ b/pom-infobec.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>anubis</groupId>
     <artifactId>anubis</artifactId>
-    <version>1.2018.9</version>
+    <version>7.2019.3</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>anubis</groupId>
 	<artifactId>anubis</artifactId>
-	<version>1.2018.9</version>
+	<version>7.2019.3</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/anubis/utils/ReflectionUtils.java
+++ b/src/main/java/anubis/utils/ReflectionUtils.java
@@ -36,9 +36,12 @@ public class ReflectionUtils {
         return classBean.getAnnotation(BeanProperties.class);
     }
 
-    /*Não valida campos da classe pai, valida Collections*/
-    public static boolean anyEmptyValue(Object o) {
-        boolean anyEmptyValue = false;
+    /**
+     * Não valida campos da classe pai, valida Collections
+     * Retorna o Field que estiver vazio, ou null caso não encontre nenhum Field vazio
+     */
+    public static Field anyEmptyValue(Object o) {
+        Field anyEmptyValue = null;
         Field[] fields = o.getClass().getDeclaredFields();
         for(Field field : fields) {
             if(!isCollection(getValue(field, o)) && !isPrimitiveType(field)) {
@@ -47,12 +50,16 @@ public class ReflectionUtils {
             }
 
             if (isEmpty(field, o)) {
-                anyEmptyValue = true;
+                anyEmptyValue = field;
                 break;
             }
         }
 
         return anyEmptyValue;
+    }
+
+    public static boolean hasAnyEmptyValue(Object o) {
+        return anyEmptyValue(o) != null;
     }
 
     private static boolean isCollection(Object obj) {
@@ -80,7 +87,7 @@ public class ReflectionUtils {
             if (collection.isEmpty()) {
                 return true;
             }
-            return collection.stream().anyMatch(ReflectionUtils::anyEmptyValue);
+            return collection.stream().anyMatch(ReflectionUtils::hasAnyEmptyValue);
         }
 
         return false;


### PR DESCRIPTION
# O que deve ser feito
Atualmente o método anyEmptyValue da classe ReflectionUtils retorna um boolean, deve ser alterado para retornar o Field que esta vazio, isso vai ajudar a mostrar para o usuário qual o campo do xml que não foi preenchido.

# O que foi feito
Alterado o método para retornar um Field.