### PR TITLE
TODOS - Sistema não exibe o mês de "Dezembro" escrito por extenso na carta de intimação

### DIFF
--- a/pom-infobec.xml
+++ b/pom-infobec.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>anubis</groupId>
     <artifactId>anubis</artifactId>
-    <version>1.2018.9</version>
+    <version>2019.17.01</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/anubis/utils/DateUtils.java
+++ b/src/main/java/anubis/utils/DateUtils.java
@@ -473,7 +473,7 @@ public class DateUtils {
 			case 8: return "Setembro";
 			case 9: return "Outubro";
 			case 10: return "Novembro";
-			case 12: return "Dezembro";
+			case 11: return "Dezembro";
 			default: return "";
 		}
 	}


### PR DESCRIPTION
TODOS - Sistema não exibe o mês de "Dezembro" escrito por extenso na carta de intimação

https://trello.com/c/Il8cSSEK/543-todos-sistema-n%C3%A3o-exibe-o-m%C3%AAs-de-dezembro-escrito-por-extenso-na-carta-de-intima%C3%A7%C3%A3o#